### PR TITLE
padding_width = 0 now works.

### DIFF
--- a/prettytable/prettytable.py
+++ b/prettytable/prettytable.py
@@ -129,7 +129,10 @@ class PrettyTable(object):
 
         self._min_table_width = kwargs["min_table_width"] or None
         self._max_table_width = kwargs["max_table_width"] or None
-        self._padding_width = kwargs["padding_width"] or 1
+        if kwargs["padding_width"] is None:
+            self._padding_width = 1
+        else:
+            self._padding_width = kwargs["padding_width"]
         self._left_padding_width = kwargs["left_padding_width"] or None
         self._right_padding_width = kwargs["right_padding_width"] or None
 

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -640,5 +640,33 @@ class PrintJapaneseTest(unittest.TestCase):
         print(self.x)
 
 
+class UnpaddedTableTest(unittest.TestCase):
+    def setUp(self):
+        self.x = PrettyTable(header=False, padding_width=0)
+        self.x.add_row("abc")
+        self.x.add_row("def")
+        self.x.add_row("g..")
+
+    def testUnbordered(self):
+        self.x.border = False
+        result = self.x.get_string()
+        assert result.strip() == """
+abc
+def
+g..
+""".strip()
+
+    def testBordered(self):
+        self.x.border = True
+        result = self.x.get_string()
+        assert result.strip() == """
++-+-+-+
+|a|b|c|
+|d|e|f|
+|g|.|.|
++-+-+-+
+""".strip()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes a bug where setting padding_width to 0 has the same effect as setting it to 1. This makes it possible to create compact tables like these:
```
+-+-+-+
|a|b|c|
|d|e|f|
|g|.|.|
+-+-+-+

abc
def
g..
```