### PR TITLE
Change from_cursor to from_db_cursor to match code

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -91,12 +91,12 @@ using a cursor object, like this:
 ::
 
     import sqlite3
-    from prettytable import from_cursor
+    from prettytable import from_db_cursor
 
     connection = sqlite3.connect("mydb.db")
     cursor = connection.cursor()
     cursor.execute("SELECT field1, field2, field3 FROM my_table")
-    mytable = from_cursor(cursor)
+    mytable = from_db_cursor(cursor)
 
 Getting data out
 ----------------


### PR DESCRIPTION
The from_cursor examples don't work because the function is not called from_cursor, but from_db_cursor: https://github.com/kxxoling/PTable/blob/master/prettytable/__init__.py#L37