### PR TITLE
"align" kwarg can be used in initialization

### DIFF
--- a/prettytable/prettytable.py
+++ b/prettytable/prettytable.py
@@ -72,7 +72,7 @@ class PrettyTable(object):
         junction_char - single character string used to draw line junctions
         sortby - name of field to sort rows by
         sort_key - sorting key function, applied to data points before sorting
-        align - default align for each row
+        align - default align for each row (None, "l", "c", "r")
         valign - default valign for each row (None, "t", "m" or "b")
         reversesort - True or False to sort in descending or ascending order
         oldsortslice - Slice rows before sorting in the "old style" """
@@ -208,7 +208,6 @@ class PrettyTable(object):
         for attr in PrettyTable.OPTIONS:
             setattr(new, "_" + attr, getattr(self, "_" + attr))
         setattr(new, "_align", getattr(self, "_align"))
-        setattr(new, "_default_align", getattr(self, "_default_align"))
         if isinstance(index, slice):
             for row in self._rows[index]:
                 new.add_row(row)

--- a/prettytable/prettytable.py
+++ b/prettytable/prettytable.py
@@ -72,7 +72,7 @@ class PrettyTable(object):
         junction_char - single character string used to draw line junctions
         sortby - name of field to sort rows by
         sort_key - sorting key function, applied to data points before sorting
-        align - default align for each row (None, "l", "c", "r")
+        align - default align for each column (None, "l", "c", or "r"). If None, defaults to "c".
         valign - default valign for each row (None, "t", "m" or "b")
         reversesort - True or False to sort in descending or ascending order
         oldsortslice - Slice rows before sorting in the "old style" """
@@ -80,8 +80,7 @@ class PrettyTable(object):
         self.encoding = kwargs.get("encoding", "UTF-8")
         self._default_align = kwargs.get("align", "c")
 
-        # Some attributes must be set before argument validation occurs because
-        # some validation uses these fields.
+        # Data
         self._field_names = []
         self._rows = []
         self.align = {}

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -733,8 +733,7 @@ class InitialOptionsPreservationTest(unittest.TestCase):
         self.x.add_row(["abc", "def", "ghi"])
         self.x.add_row("jkl")
 
-    def testBordered(self):
-        self.x.border = True
+    def testAlign(self):
         result = self.x.get_string()
         self.assertEqual(result.strip(), """
 +---+---+---+

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -727,5 +727,21 @@ g..
 """.strip())
 
 
+class InitialOptionsPreservationTest(unittest.TestCase):
+    def setUp(self):
+        self.x = PrettyTable(align='l', header=False, padding_width=0)
+        self.x.add_row(["abc", "def", "ghi"])
+        self.x.add_row("jkl")
+
+    def testBordered(self):
+        self.x.border = True
+        result = self.x.get_string()
+        self.assertEqual(result.strip(), """
++---+---+---+
+|abc|def|ghi|
+|j  |k  |l  |
++---+---+---+
+""".strip())
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Modified so that "align" can be used once during initialization and is not required again after adding data (especially columns) to the table.

P.S. If you accept this, I'll do it for several other initialization args that don't persist (like float_format).