### PR TITLE
Fixed a typo: PLAIN_COLUMN => PLAIN_COLUMNS

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -389,7 +389,7 @@ in-built styles you can use for your tables:
 
 -  ``DEFAULT`` - The default look, used to undo any style changes you
    may have made
--  ``PLAIN_COLUMN`` - A borderless style that works well with command
+-  ``PLAIN_COLUMNS`` - A borderless style that works well with command
    line programs for columnar data
 
 Other styles are likely to appear in future releases.


### PR DESCRIPTION
Updated PLAIN_COLUMNS constant can be found in the wiki: https://code.google.com/archive/p/prettytable/wikis/Tutorial.wiki