### PR TITLE
Automatically load exported style names

### DIFF
--- a/prettytable/__init__.py
+++ b/prettytable/__init__.py
@@ -33,5 +33,6 @@
 __version__ = "0.9.2"
 
 from .prettytable import PrettyTable
-from .prettytable import ALL, HEADER, MSWORD_FRIENDLY, NONE
+from .prettytable import FRAME, ALL, NONE, HEADER
+from .prettytable import DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM
 from .factory import from_csv, from_db_cursor, from_html, from_html_one


### PR DESCRIPTION
In the tutorial, we can set the style via `set_style`, and one of the style `MSWORD_FRIENDLY` can be used as following:
```python
from prettytable import MSWORD_FRIENDLY
```

It also mentioned there are another styles, e.g., `PLAIN_COLUMNS`. However, it failed to import via the same way.
```python
from prettytable import PLAIN_COLUMNS
```
result:
```
Traceback (most recent call last):
  File "./pptest.py", line 3, in <module>
    from prettytable import PLAIN_COLUMNS
ImportError: cannot import name PLAIN_COLUMNS
```

I am unable to solve it until tracing the source code, and change to the following import statement:
```python
from prettytable.prettytable import PLAIN_COLUMNS
```

I am of the opinion that it should automatically load all exported styles instead of only partial ones. If not, it should then add some notes in tutorial to clarify the usage.