### PR TITLE
fix import for PLAIN_COLUMNS style

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -389,7 +389,7 @@ in-built styles you can use for your tables:
 
 -  ``DEFAULT`` - The default look, used to undo any style changes you
    may have made
--  ``PLAIN_COLUMN`` - A borderless style that works well with command
+-  ``PLAIN_COLUMNS`` - A borderless style that works well with command
    line programs for columnar data
 
 Other styles are likely to appear in future releases.

--- a/prettytable/__init__.py
+++ b/prettytable/__init__.py
@@ -33,5 +33,5 @@
 __version__ = "0.9.2"
 
 from .prettytable import PrettyTable
-from .prettytable import ALL, HEADER, MSWORD_FRIENDLY, NONE
+from .prettytable import ALL, HEADER, MSWORD_FRIENDLY, NONE, PLAIN_COLUMNS
 from .factory import from_csv, from_db_cursor, from_html, from_html_one


### PR DESCRIPTION
Example from documentation works only for MSWORD_FRIENDLY style

```python
from prettytable import MSWORD_FRIENDLY       # works
from prettytable import PLAIN_COLUMNS         # broken
```
    
This commit fixes import for PLAIN_COLUMNS style.

I would suggest to also add `DEFAULT` to `__init__.py`. But I kept my commit intentionally simple.