### PR TITLE
support markdown output string and reStructuredText output string

### DIFF
--- a/prettytable/prettytable.py
+++ b/prettytable/prettytable.py
@@ -1400,7 +1400,7 @@ class PrettyTable(object):
     # MARKDOWN TEXT STRING METHODS #
     ################################
 
-    def get_markdown(self, **kwargs):
+    def get_md_string(self, **kwargs):
 
         """Return string representation of table in markdown.
 
@@ -1424,7 +1424,7 @@ class PrettyTable(object):
         lines = self._prepare_lines(**kwargs)
         return self._unicode("\n").join(lines)
 
-    def get_rst(self, **kwargs):
+    def get_rst_string(self, **kwargs):
 
         """Return string representation of table in reStructuredText.
 

--- a/prettytable/prettytable.py
+++ b/prettytable/prettytable.py
@@ -1144,6 +1144,51 @@ class PrettyTable(object):
     # PLAIN TEXT STRING METHODS  #
     ##############################
 
+    def _prepare_lines(self, **kwargs):
+
+        """Return a list of lines, for building the return-string of `get_string`.
+        Arguments: see method `get_string`.
+        """
+
+        options = self._get_options(kwargs)
+
+        lines = []
+
+        # Don't think too hard about an empty table
+        # Is this the desired behaviour?  Maybe we should still print the header?
+        if self.rowcount == 0 and (not options["print_empty"] or not options["border"]):
+            return []
+
+        # Get the rows we need to print, taking into account slicing, sorting, etc.
+        rows = self._get_rows(options)
+
+        # Turn all data in all rows into Unicode, formatted as desired
+        formatted_rows = self._format_rows(rows, options)
+
+        # Compute column widths
+        self._compute_widths(formatted_rows, options)
+        self._hrule = self._stringify_hrule(options)
+
+        # Add title
+        title = options["title"] or self._title
+        if title:
+            lines.append(self._stringify_title(title, options))
+
+        # Add header or top of border
+        if options["header"]:
+            lines.extend(self._stringify_header(options).split('\n'))
+        elif options["border"] and options["hrules"] in (ALL, FRAME):
+            lines.append(self._hrule)
+
+        # Add rows
+        for row in formatted_rows:
+            lines.append(self._stringify_row(row, options))
+
+        # Add bottom of border
+        if options["border"] and options["hrules"] == FRAME:
+            lines.append(self._hrule)
+        return lines
+
     def get_string(self, **kwargs):
 
         """Return string representation of table in current state.
@@ -1170,45 +1215,7 @@ class PrettyTable(object):
         sort_key - sorting key function, applied to data points before sorting
         reversesort - True or False to sort in descending or ascending order
         print empty - if True, stringify just the header for an empty table, if False return an empty string """
-
-        options = self._get_options(kwargs)
-
-        lines = []
-
-        # Don't think too hard about an empty table
-        # Is this the desired behaviour?  Maybe we should still print the header?
-        if self.rowcount == 0 and (not options["print_empty"] or not options["border"]):
-            return ""
-
-        # Get the rows we need to print, taking into account slicing, sorting, etc.
-        rows = self._get_rows(options)
-
-        # Turn all data in all rows into Unicode, formatted as desired
-        formatted_rows = self._format_rows(rows, options)
-
-        # Compute column widths
-        self._compute_widths(formatted_rows, options)
-        self._hrule = self._stringify_hrule(options)
-
-        # Add title
-        title = options["title"] or self._title
-        if title:
-            lines.append(self._stringify_title(title, options))
-
-        # Add header or top of border
-        if options["header"]:
-            lines.append(self._stringify_header(options))
-        elif options["border"] and options["hrules"] in (ALL, FRAME):
-            lines.append(self._hrule)
-
-        # Add rows
-        for row in formatted_rows:
-            lines.append(self._stringify_row(row, options))
-
-        # Add bottom of border
-        if options["border"] and options["hrules"] == FRAME:
-            lines.append(self._hrule)
-
+        lines = self._prepare_lines(**kwargs)
         return self._unicode("\n").join(lines)
 
     def _stringify_hrule(self, options):
@@ -1388,6 +1395,60 @@ class PrettyTable(object):
                 break
             kwargs["start"] += page_length
         return "\f".join(pages)
+
+    ################################
+    # MARKDOWN TEXT STRING METHODS #
+    ################################
+
+    def get_markdown(self, **kwargs):
+
+        """Return string representation of table in markdown.
+
+        Arguments:
+
+        start - index of first data row to include in output
+        end - index of last data row to include in output PLUS ONE (list slice style)
+        fields - names of fields (columns) to include
+        int_format - controls formatting of integer data
+        float_format - controls formatting of floating point data
+        sortby - name of field to sort rows by
+        sort_key - sorting key function, applied to data points before sorting
+        reversesort - True or False to sort in descending or ascending order
+        print empty - if True, stringify just the header for an empty table, if False return an empty string """
+
+        kwargs['title'] = None
+        kwargs['header'] = True
+        kwargs['border'] = True
+        kwargs['junction_char'] = '|'
+        kwargs['hrules'] = HEADER
+        lines = self._prepare_lines(**kwargs)
+        return self._unicode("\n").join(lines)
+
+    def get_rst(self, **kwargs):
+
+        """Return string representation of table in reStructuredText.
+
+        Arguments:
+
+        start - index of first data row to include in output
+        end - index of last data row to include in output PLUS ONE (list slice style)
+        fields - names of fields (columns) to include
+        int_format - controls formatting of integer data
+        float_format - controls formatting of floating point data
+        sortby - name of field to sort rows by
+        sort_key - sorting key function, applied to data points before sorting
+        reversesort - True or False to sort in descending or ascending order
+        print empty - if True, stringify just the header for an empty table, if False return an empty string """
+
+        kwargs['title'] = None
+        kwargs['header'] = True
+        kwargs['border'] = True
+        kwargs['hrules'] = ALL
+        lines = self._prepare_lines(**kwargs)
+        # line-0 is _hrule, line-1 is header, line-2 is _hrule
+        if len(lines) >= 3:
+            lines[2] = lines[2].replace('-', '=')
+        return self._unicode("\n").join(lines)
 
     ##############################
     # HTML STRING METHODS        #

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -734,7 +734,7 @@ class PrintMarkdownAndRstTest(unittest.TestCase):
         self.x.add_row(["aa", "bb", "cc"])
 
     def testMarkdownOutput(self):
-        result = self.x.get_markdown()
+        result = self.x.get_md_string()
         print()
         print(result)
         self.assertEqual(result.strip(), """
@@ -745,7 +745,7 @@ class PrintMarkdownAndRstTest(unittest.TestCase):
 """.strip())
 
     def testRstOutput(self):
-        result = self.x.get_rst()
+        result = self.x.get_rst_string()
         print()
         print(result)
         self.assertEqual(result.strip(), """

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -727,5 +727,37 @@ g..
 """.strip())
 
 
+class PrintMarkdownAndRstTest(unittest.TestCase):
+    def setUp(self):
+        self.x = PrettyTable(["A", "B", "C"])
+        self.x.add_row(["a", "b", "c"])
+        self.x.add_row(["aa", "bb", "cc"])
+
+    def testMarkdownOutput(self):
+        result = self.x.get_markdown()
+        print()
+        print(result)
+        self.assertEqual(result.strip(), """
+| A  | B  | C  |
+|----|----|----|
+| a  | b  | c  |
+| aa | bb | cc |
+""".strip())
+
+    def testRstOutput(self):
+        result = self.x.get_rst()
+        print()
+        print(result)
+        self.assertEqual(result.strip(), """
++----+----+----+
+| A  | B  | C  |
++====+====+====+
+| a  | b  | c  |
++----+----+----+
+| aa | bb | cc |
++----+----+----+
+""".strip())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
add method `get_markdown` for markdown output:

``` 
| A  | B  | C  |
|----|----|----|
| a  | b  | c  |
| aa | bb | cc |
```

and add method `get_rst` for reStructuredText output:

```
+----+----+----+
| A  | B  | C  |
+====+====+====+
| a  | b  | c  |
+----+----+----+
| aa | bb | cc |
+----+----+----+
```