### PR TITLE
Add Python 3.7 support and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
+
+matrix:
+  include:
+  - python: "2.7"
+  - python: "3.4"
+  - python: "3.5"
+  - python: "3.6"
+  - python: "3.7"
+    dist: xenial
+    sudo: required
 
 install:
     - "pip install -r req-dev.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 install:
     - "pip install -r req-dev.txt"

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'License :: OSI Approved :: BSD License',
         'Topic :: Text Processing'


### PR DESCRIPTION
Travis CI requires Xenial and sudo for Python 3.7. 

See https://github.com/travis-ci/travis-ci/issues/9069.