### PR TITLE
Fixes literal syntax warnings with Python 3.8

### DIFF
--- a/prettytable/prettytable.py
+++ b/prettytable/prettytable.py
@@ -421,7 +421,7 @@ class PrettyTable(object):
     def align(self, val):
         if not self._field_names:
             self._align = {}
-        elif val is None or (isinstance(val, dict) and len(val) is 0):
+        elif val is None or (isinstance(val, dict) and len(val) == 0):
             for field in self._field_names:
                 self._align[field] = "c"
         else:
@@ -441,7 +441,7 @@ class PrettyTable(object):
     def valign(self, val):
         if not self._field_names:
             self._valign = {}
-        elif val is None or (isinstance(val, dict) and len(val) is 0):
+        elif val is None or (isinstance(val, dict) and len(val) == 0):
             for field in self._field_names:
                 self._valign[field] = "t"
         else:
@@ -459,7 +459,7 @@ class PrettyTable(object):
 
     @max_width.setter
     def max_width(self, val):
-        if val is None or (isinstance(val, dict) and len(val) is 0):
+        if val is None or (isinstance(val, dict) and len(val) == 0):
             self._max_width = {}
         else:
             self._validate_option("max_width", val)
@@ -489,7 +489,7 @@ class PrettyTable(object):
 
     @min_width.setter
     def min_width(self, val):
-        if val is None or (isinstance(val, dict) and len(val) is 0):
+        if val is None or (isinstance(val, dict) and len(val) == 0):
             self._min_width = {}
         else:
             self._validate_option("min_width", val)
@@ -687,7 +687,7 @@ class PrettyTable(object):
 
     @int_format.setter
     def int_format(self, val):
-        if val is None or (isinstance(val, dict) and len(val) is 0):
+        if val is None or (isinstance(val, dict) and len(val) == 0):
             self._int_format = {}
         else:
             self._validate_option("int_format", val)
@@ -704,7 +704,7 @@ class PrettyTable(object):
 
     @float_format.setter
     def float_format(self, val):
-        if val is None or (isinstance(val, dict) and len(val) is 0):
+        if val is None or (isinstance(val, dict) and len(val) == 0):
             self._float_format = {}
         else:
             self._validate_option("float_format", val)


### PR DESCRIPTION
Fixes the `SyntaxWarning: "is" with a literal. Did you mean "=="?` added by Python 3.8

Partial fix for #37 